### PR TITLE
Add EXT_TIM_VX to specify TIM-VX remote location

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The OPENVX_SDK directory should originized as in prebuild/android_arm64/
 
 Reference for cmake variable in android toolchain: <https://developer.android.com/ndk/guides/cmake>
 
+### Build with specific TIM-VX remote
+
+Addition cmake definition added for this purpose -DEXT_TIM_VX=<git remote location url>, just provide the git remote location url to get TIM-VX code.
+
 ### Build with specific TIM-VX version
 
 Addition cmake definition added for this purpose -DTIM_VX_TAG=commit-sha-id, just provide the commit id in TIM-VX github repo.

--- a/cmake/module/TimVxConfig.cmake
+++ b/cmake/module/TimVxConfig.cmake
@@ -23,6 +23,10 @@ if(NOT PUBLIC_TIM_VX)
     set(repo_addr git@gitlab-cn.verisilicon.com:npu_sw/verisilicon/tim-vx.git)
 endif()
 
+if(EXT_TIM_VX)
+    set(repo_addr ${EXT_TIM_VX})
+endif()
+
 if(NOT TIM_VX_TAG)
 set(TIM_VX_TAG "main")
 endif()


### PR DESCRIPTION
This support building TIM-VX from a specified remote location with the below args:
-DEXT_TIM_VX=<git remote url>